### PR TITLE
feat: 新增一键复制排盘结果功能（含九宫详解与AI看盘提示）

### DIFF
--- a/lib/jieduan.js
+++ b/lib/jieduan.js
@@ -51,6 +51,7 @@ const XING_INFO = {
     '天冲': { element: 'mu', alias: '禄存', feature: '主冲击、变化、快速' },
     '天辅': { element: 'mu', alias: '文曲', feature: '主扶助、文书、辅佐' },
     '天禽': { element: 'tu', alias: '天禽', feature: '中宫之星，主枢纽、核心' },
+    '禽芮': { element: 'tu', alias: '天禽', feature: '天禽寄坤宫与天芮同宫，主枢纽、疾病' },
     '天心': { element: 'jin', alias: '廉贞', feature: '主决断、医药、果决' },
     '天柱': { element: 'jin', alias: '破军', feature: '主坚固、口舌、破耗' },
     '天任': { element: 'tu', alias: '巨门', feature: '主责任、稳实、田产' },
@@ -347,7 +348,7 @@ function buildExplain(a) {
     // 天地盘干与克应
     if (a.tianGan && a.diGan) {
         let s = `天盘${a.tianGan}加地盘${a.diGan}`;
-        if (a.keYing) s += `，为「${a.keYing.name}」(${JIXIONG_TEXT[a.keYing.jiXiong] || ''})，${a.keYing.explain}`;
+        if (a.keYing) s += `，为「${a.keYing.name}」(${ {ji:'吉', xiong:'凶', ping:'平'}[a.keYing.jiXiong] || '' })，${a.keYing.explain}`;
         parts.push(s + '。');
     }
 

--- a/public/css/style-new.css
+++ b/public/css/style-new.css
@@ -552,3 +552,20 @@ body {
         width: 49%;
     }
 }
+.copy-btn-row {
+    margin: 18px 0 6px;
+}
+.copy-btn-row .btn {
+    padding: 8px 22px;
+    font-size: 15px;
+}
+.copy-tip {
+    margin-left: 12px;
+    color: #5cb85c;
+    font-size: 13px;
+    opacity: 0;
+    transition: opacity .3s;
+}
+.copy-tip.show {
+    opacity: 1;
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -6,21 +6,253 @@ $(document).ready(function() {
         String(now.getDate()).padStart(2, '0');
     var timeStr = String(now.getHours()).padStart(2, '0') + ':' +
         String(now.getMinutes()).padStart(2, '0');
-
     $('#date').val(dateStr);
     $('#time').val(timeStr);
-
     // 自定义排盘表单提交
     $('#submitCustomPan').click(function() {
         $('#customPanForm').submit();
     });
-
     // 确保九宫格始终保持正方形比例
     function maintainAspectRatio() {
         var gridWidth = $('.pan-grid').width();
         $('.gong').css('height', gridWidth / 3 + 'px');
     }
-
     maintainAspectRatio();
     $(window).resize(maintainAspectRatio);
+
+    // 一键复制排盘结果
+    $('#copyPanBtn').on('click', function() {
+        var pan = window.QIMEN_PAN_DATA;
+        if (!pan) {
+            alert('排盘数据尚未加载，无法复制');
+            return;
+        }
+        var text = buildCopyText(pan);
+        copyText(text, function(ok) {
+            var $tip = $('#copyTip');
+            if (ok) {
+                $tip.addClass('show');
+                setTimeout(function() { $tip.removeClass('show'); }, 2500);
+            } else {
+                alert('复制失败，请手动选择页面内容复制');
+            }
+        });
+    });
 });
+
+/**
+ * 把排盘数据拼成便于分享的纯文本
+ */
+function buildCopyText(pan) {
+    // 按显示宽度补齐（中文/全角占 2 列）
+    function dispWidth(s) {
+        s = String(s == null ? '' : s);
+        var w = 0;
+        for (var i = 0; i < s.length; i++) {
+            var c = s.charCodeAt(i);
+            w += (c >= 0x2E80 && c <= 0x9FFF) ||
+                 (c >= 0xAC00 && c <= 0xD7A3) ||
+                 (c >= 0xF900 && c <= 0xFAFF) ||
+                 (c >= 0xFE30 && c <= 0xFE6F) ||
+                 (c >= 0xFF00 && c <= 0xFF60) ||
+                 (c >= 0xFFE0 && c <= 0xFFE6) ? 2 : 1;
+        }
+        return w;
+    }
+    function padR(s, w) {
+        s = String(s == null ? '' : s);
+        var d = w - dispWidth(s);
+        return d > 0 ? s + new Array(d + 1).join(' ') : s;
+    }
+    function padC(s, w) {
+        s = String(s == null ? '' : s);
+        var d = w - dispWidth(s);
+        if (d <= 0) return s;
+        var l = Math.floor(d / 2);
+        return new Array(l + 1).join(' ') + s + new Array(d - l + 1).join(' ');
+    }
+
+    var b = pan.basicInfo || {};
+    var sz = pan.siZhu || {};
+    var js = pan.juShu || {};
+    var an = pan.analysis || {};
+    var ga = pan.jiuGongAnalysis || {};
+    var METHOD_CN = {'时家':'时家奇门','日家':'日家奇门','月家':'月家奇门','年家':'年家奇门'};
+    var methodText = METHOD_CN[b.method] || b.method || '';
+    var L = [];
+
+    L.push('【奇门遁甲排盘】');
+    L.push('公历：' + (b.date || ''));
+    L.push('农历：' + (b.lunarDate || ''));
+    L.push('四柱：' + [sz.year, sz.month, sz.day, sz.time].filter(Boolean).join(' '));
+    L.push('排盘方法：' + methodText + '　排盘类型：' + (b.type || ''));
+    L.push('局数：' + (js.fullName || '') + '　旬首：' + (pan.xunShou || ''));
+    L.push('值符：' + (pan.zhiFuXing || '') + '(' + (pan.zhiFuGong || '') + '宫)'
+         + '　值使：' + (pan.zhiShiMen || '') + '(' + (pan.zhiShiGong || '') + '宫)');
+    var kw = (pan.kongWangZhi || []).join('') || '无';
+    var ma = (pan.maStar && pan.maStar.zhi) || '无';
+    L.push('空亡：' + kw + '　驿马：' + ma + '　运势：' + (an.overallJiXiongText || ''));
+    L.push('');
+
+    // 九宫格（屏幕排列：4-9-2 / 3-5-7 / 8-1-6）
+    var NUM_CN = {'1':'一','2':'二','3':'三','4':'四','5':'五','6':'六','7':'七','8':'八','9':'九'};
+    var layout = [['4','9','2'], ['3','5','7'], ['8','1','6']];
+    var CW = 9;
+    function cellLines(g) {
+        var a = ga[g] || {};
+        var name = (a.gongName || '') + (NUM_CN[g] || '');
+        var shen = a.shen || '';
+        var xing = a.xing || '';
+        var men  = a.men || '';
+        var td   = a.tianGan && a.diGan ? a.tianGan + '加' + a.diGan : '';
+        // 末行：暗干 + 空亡/驿马标记
+        var tail = '';
+        if (a.anGan) tail += '暗' + a.anGan;
+        if (a.kongWang) tail += ' 空';
+        if (a.yiMa) tail += ' 马';
+        return [
+            padC(name, CW),
+            padC(shen, CW),
+            padC(xing, CW),
+            padC(men, CW),
+            padC(td, CW),
+            padC(tail, CW)
+        ];
+    }
+    function rowBorder(left, mid, right) {
+        var seg = new Array(CW + 3).join('─');
+        return left + seg + mid + seg + mid + seg + right;
+    }
+    L.push(rowBorder('┌', '┬', '┐'));
+    for (var r = 0; r < layout.length; r++) {
+        var cells = layout[r].map(cellLines);
+        for (var li = 0; li < 6; li++) {
+            L.push('│ ' + cells[0][li] + ' │ ' + cells[1][li] + ' │ ' + cells[2][li] + ' │');
+        }
+        if (r < layout.length - 1) L.push(rowBorder('├', '┼', '┤'));
+    }
+    L.push(rowBorder('└', '┴', '┘'));
+    L.push('');
+
+    // 格局
+    L.push('【格局】');
+    if (pan.geju && pan.geju.length) {
+        pan.geju.forEach(function(g) {
+            var tag = g.jiXiong === 'ji' ? '[吉]' : g.jiXiong === 'xiong' ? '[凶]' : '[平]';
+            var where = g.gong ? '（' + g.gong + '宫）' : '';
+            L.push(tag + ' ' + g.name + where + ' — ' + g.explain);
+        });
+    } else {
+        L.push('本盘未见显著格局。');
+    }
+    L.push('');
+
+    // 分析与建议
+    L.push('【分析与建议】');
+    var zf = ga[pan.zhiFuGong] || {};
+    var zs = ga[pan.zhiShiGong] || {};
+    L.push('值符：' + (pan.zhiFuGong || '') + '宫(' + (zf.gongName || '中') + ')'
+         + '，值使：' + (pan.zhiShiGong || '') + '宫(' + (zs.gongName || '中') + ')');
+    if (an.bestGong && ga[an.bestGong]) {
+        L.push('最有利方位：' + (ga[an.bestGong].direction || '') + '(' + ga[an.bestGong].gongName + '宫)');
+    }
+    if (an.yongShen) {
+        L.push('用神：' + an.yongShen.name + ' 落' + (an.yongShen.direction || '')
+             + '(' + (an.yongShen.gongName || '') + '宫)，' + (an.yongShen.jiXiongText || ''));
+    }
+    if (an.suggestions && an.suggestions.length) {
+        an.suggestions.forEach(function(s, i) {
+            L.push((i + 1) + '. ' + s);
+        });
+    }
+    L.push('');
+
+    // 九宫详解
+    L.push('【九宫详解】');
+    for (var gi = 1; gi <= 9; gi++) {
+        var a = ga[gi];
+        if (!a) continue;
+        var head = gi + '宫 ' + (a.gongName || '') + '（' + (a.direction || '') + '）'
+                 + (a.jiXiongText || '');
+        var elems = [];
+        if (a.shen) elems.push(a.shen);
+        if (a.xing) elems.push(a.xing + (a.xingAlias ? '(' + a.xingAlias + ')' : ''));
+        if (a.men) elems.push(a.men);
+        var ganLine = '';
+        if (a.tianGan || a.diGan) ganLine = (a.tianGan || '') + '加' + (a.diGan || '');
+        if (a.anGan) ganLine += (ganLine ? ' ' : '') + '暗' + a.anGan;
+        var tags = [];
+        if (a.keYing) tags.push('[' + (a.keYing.jiXiong === 'ji' ? '吉' : a.keYing.jiXiong === 'xiong' ? '凶' : '平') + ']' + a.keYing.name);
+        if (a.menPo) tags.push('门迫');
+        if (a.kongWang) tags.push('空亡');
+        if (a.yiMa) tags.push('驿马');
+        L.push(head + (elems.length ? '｜' + elems.join('·') : '')
+                 + (ganLine ? '｜' + ganLine : '')
+                 + (tags.length ? '｜' + tags.join(' ') : ''));
+        if (a.explain) L.push(a.explain);
+        L.push('');
+    }
+
+    // AI 看盘提示（随盘复制，约束 AI 严格按本盘解断，勿自行排盘或生造格局）
+    var YONGSHEN_TIP = {
+        '事业': '事业看开门、值符所临之宫，宫吉门旺则升迁顺遂',
+        '财运': '求财看生门、戊(财星)所临之宫，逢生旺吉、忌空亡入墓',
+        '婚姻': '婚姻看六合、乙(婚星)所临之宫，逢吉门相生为成',
+        '健康': '疾病看天心(医星)、生门所临之宫，忌天芮、死门',
+        '学业': '考学看天辅(文星)、景门(文书)所临之宫，逢吉则名扬',
+        '出行': '出行看开门、驿马所临之宫，忌伤门、杜门',
+        '失物': '失物盗贼看玄武所临之宫，其方位为线索所在',
+        '综合': '综合判断以值符值使为纲，结合所问之事取用神'
+    };
+    var purpose = (b.purpose || '综合');
+    var yongshenTip = YONGSHEN_TIP[purpose] || YONGSHEN_TIP['综合'];
+    L.push('【AI看盘提示】');
+    L.push('以下为茅山派转盘奇门遁甲排盘结果，请严格按以下规则分析，勿自行重新排盘或改动盘内数据：');
+    L.push('1. 排盘参数：' + methodText + '，' + (js.fullName || '') + '，值符' + (pan.zhiFuXing || '')
+         + '落' + (pan.zhiFuGong || '') + '宫、值使' + (pan.zhiShiMen || '') + '落' + (pan.zhiShiGong || '') + '宫，为全盘纲领。');
+    L.push('2. 严格以本盘所列星门神干为准；天禽寄坤二宫(显示"禽芮")，中五宫不排星门神、寄坤二宫论。');
+    L.push('3. 吉凶判断规则：');
+    L.push('   - 八门：休/生/开/景为吉门，伤/杜/死/惊为凶门；');
+    L.push('   - 八神：值符/太阴/六合/九地/九天为吉，腾蛇/白虎/玄武为凶；');
+    L.push('   - 门迫(门克宫)为重要凶象，吉门减力、凶门更凶；宫克门则门受制；');
+    L.push('   - 空亡之宫吉凶力量减半，所主之事易落空、宜实不宜虚；');
+    L.push('   - 驿马临宫主变动、出行、远行有利；');
+    L.push('   - 十干克应与格局只按盘中标注判读(如青龙返首、飞鸟跌穴、六仪击刑、五不遇时、奇仪入墓、九星伏吟/反吟等)，勿编造盘外格局。');
+    L.push('4. 用神取用：' + yongshenTip + '。');
+    L.push('5. 输出要求：先断总体吉凶(以值符值使落宫为纲)，再析用神落宫与关键格局，次论各宫生克，最后给出可执行建议；不确定处明确说明，勿臆断。');
+
+    return L.join('\n');
+}
+
+/**
+ * 复制文本到剪贴板：优先 Clipboard API，失败回退 execCommand
+ */
+function copyText(text, cb) {
+    if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(text).then(function() {
+            cb(true);
+        }).catch(function() {
+            fallbackCopy(text, cb);
+        });
+    } else {
+        fallbackCopy(text, cb);
+    }
+}
+function fallbackCopy(text, cb) {
+    try {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.top = '-9999px';
+        ta.style.left = '-9999px';
+        ta.setAttribute('readonly', '');
+        document.body.appendChild(ta);
+        ta.select();
+        ta.setSelectionRange(0, ta.value.length);
+        var ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+        cb(ok);
+    } catch (e) {
+        cb(false);
+    }
+}

--- a/views/index.html
+++ b/views/index.html
@@ -83,6 +83,10 @@
                     <div class="info-item">
                         <strong>运势:</strong> <span id="overallLuck" class="<%= qimen.analysis && qimen.analysis.overallJiXiong || 'ping' %>"><%= qimen.analysis && qimen.analysis.overallJiXiongText || '平' %></span>
                     </div>
+                    <div class="copy-btn-row">
+                        <button type="button" class="btn btn-success" id="copyPanBtn">一键复制排盘结果</button>
+                        <span id="copyTip" class="copy-tip">已复制到剪贴板，可直接粘贴分享</span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -531,6 +535,7 @@
     <script src="js/jquery.min.js"></script>
     <!-- Bootstrap JavaScript -->
     <script src="js/bootstrap.min.js"></script>
+    <script>window.QIMEN_PAN_DATA = <%- JSON.stringify(qimen) %>;</script>
     <script src="js/app.js"></script>
 </body>
 


### PR DESCRIPTION
<img width="1260" height="1307" alt="Screenshot_20260822_091850" src="https://github.com/user-attachments/assets/698d55ff-7e20-499c-b0c2-047c40c95229" />

# 示例
【奇门遁甲排盘】
公历：2026-08-22 09:13:42 星期六 狮子座
农历：二〇二六年七月初十
四柱：丙午 丙申 戊辰 丁巳
排盘方法：时家奇门　排盘类型：四柱
局数：阴遁2局 (上元)　旬首：癸
值符：天心(2宫)　值使：开门(3宫)
空亡：子丑　驿马：亥　运势：平

┌───────────┬───────────┬───────────┐
│   巽四    │   离九    │   坤二    │
│   太阴    │   腾蛇    │   值符    │
│   禽芮    │   天柱    │   天心    │
│   休门    │   生门    │   伤门    │
│  戊加丙   │  壬加庚   │  癸加戊   │
│   暗癸    │   暗戊    │   暗丙    │
├───────────┼───────────┼───────────┤
│   震三    │   中五    │   兑七    │
│   六合    │           │   九天    │
│   天英    │           │   天蓬    │
│   开门    │           │   杜门    │
│  庚加乙   │  丁加丁   │  己加壬   │
│   暗丁    │   暗壬    │   暗庚    │
├───────────┼───────────┼───────────┤
│   艮八    │   坎一    │   乾六    │
│   白虎    │   玄武    │   九地    │
│   天辅    │   天冲    │   天任    │
│   惊门    │   死门    │   景门    │
│  丙加辛   │  乙加己   │  辛加癸   │
│  暗己 空  │  暗乙 空  │  暗辛 马  │
└───────────┴───────────┴───────────┘

【格局】
[吉] 三奇得使（1宫） — 坎宫乙奇得地盘己仪之使，利于用事、有贵助。
[吉] 天乙合会（2宫） — 坤宫天盘癸加地盘戊：婚姻财喜，合作投资吉
[吉] 青龙返首（4宫） — 巽宫天盘戊加地盘丙：大吉大利，唯无吉门则吉事成凶

【分析与建议】
值符：2宫(坤)，值使：3宫(震)
最有利方位：东南(巽宫)
1. 时运平平，宜按部就班、不宜冒进。
2. 全盘最有利在东南方(巽宫，大吉)，可多往此方位用事。
3. 本盘见吉格：三奇得使、天乙合会、青龙返首，可借势而为。

【九宫详解】
1宫 坎（正北）小凶｜玄武·天冲(禄存)·死门｜乙加己 暗乙｜[凶]日奇入墓 门迫 空亡
坎宫主水，关乎事业、财源、流动、隐秘。 天冲(禄存)入宫，主冲击、变化、快速。 死门临宫，凶门，主死丧停滞，宜吊丧断事。 玄武临宫，凶神，主盗贼欺诈、暗昧。 天盘乙加地盘己，为「日奇入墓」(凶)，被土暗昧，门凶事凶。 宫生星，得生有力。 门迫(门克宫)，吉门减力、凶门更凶。 此宫值空亡，吉凶力量减半，所主之事易落空、宜实不宜虚。 综断此宫小凶，多有阻碍，宜守不宜进。

2宫 坤（西南）平｜值符·天心(廉贞)·伤门｜癸加戊 暗丙｜[吉]天乙合会 门迫
坤宫主土，关乎婚姻、母亲、田宅、众人。 天心(廉贞)入宫，主决断、医药、果决。 伤门临宫，凶门，主伤损疾病，宜捕猎索债。 值符临宫，贵神，主贵人福庆。 天盘癸加地盘戊，为「天乙合会」(吉)，婚姻财喜，合作投资吉。 宫生星，得生有力。 门迫(门克宫)，吉门减力、凶门更凶。 综断此宫平平，按部就班、谨慎行事。

3宫 震（正东）平｜六合·天英(左辅)·开门｜庚加乙 暗丁｜[凶]太白逢星 门迫
震宫主木，关乎创业、动作、长男、惊扰。 天英(左辅)入宫，主才华、显贵，亦主血光。 开门临宫，吉门，主通达开拓，宜开业出行。 六合临宫，吉神，主和合婚姻、中介。 天盘庚加地盘乙，为「太白逢星」(凶)，流连牵绊，夫妻不和。 宫生星，得生有力。 门迫(门克宫)，吉门减力、凶门更凶。 综断此宫平平，按部就班、谨慎行事。

4宫 巽（东南）大吉｜太阴·禽芮(天禽)·休门｜戊加丙 暗癸｜[吉]青龙返首
巽宫主木，关乎文书、女子、风评、出行。 禽芮(天禽)入宫，天禽寄坤宫与天芮同宫，主枢纽、疾病。 休门临宫，吉门，主休养安宁，宜休息谒贵。 太阴临宫，吉神，主暗助阴贵、谋密。 天盘戊加地盘丙，为「青龙返首」(吉)，大吉大利，唯无吉门则吉事成凶。 宫克星，受制不利。 门生宫，泄气耗力。 综断此宫大吉，可主动进取。

5宫 中（中宫）小吉｜丁加丁 暗壬｜[吉]星奇伏吟
中宫为枢，统领八方，关乎自身、核心。 天盘丁加地盘丁，为「星奇伏吟」(吉)，文书即至，万事如意。 综断此宫小吉，稳步推进为宜。

6宫 乾（西北）小凶｜九地·天任(巨门)·景门｜辛加癸 暗辛｜[凶]天牢华盖 门迫 驿马
乾宫主金，关乎父亲、权威、官贵、远行。 天任(巨门)入宫，主责任、稳实、田产。 景门临宫，吉门(平)，主文书光明，宜考试献策。 九地临宫，吉神，主柔顺稳固、藏纳。 天盘辛加地盘癸，为「天牢华盖」(凶)，日月失明，动辄乖张。 星生宫，泄气耗力。 门迫(门克宫)，吉门减力、凶门更凶。 驿马临宫，主动象、变动、出行远行有利。 综断此宫小凶，多有阻碍，宜守不宜进。

7宫 兑（正西）小凶｜九天·天蓬(贪狼)·杜门｜己加壬 暗庚｜[凶]地网高张
兑宫主金，关乎口舌、沟通、少女、毁折。 天蓬(贪狼)入宫，主智慧、口才、机变。 杜门临宫，凶门，主阻塞隐避，宜躲藏防守。 九天临宫，吉神，主高远扬名、出行。 天盘己加地盘壬，为「地网高张」(凶)，奸情伤杀，事多变动。 宫生星，得生有力。 宫克门，受制不利。 综断此宫小凶，多有阻碍，宜守不宜进。

8宫 艮（东北）平｜白虎·天辅(文曲)·惊门｜丙加辛 暗己｜[吉]月奇相合 空亡
艮宫主土，关乎阻隔、变化、少男、田产。 天辅(文曲)入宫，主扶助、文书、辅佐。 惊门临宫，凶门，主惊恐口舌，宜诉讼擒拿。 白虎临宫，凶神，主凶伤道路、争斗。 天盘丙加地盘辛，为「月奇相合」(吉)，凶象被合，谋事成就。 星克宫。 宫生门，得生有力。 此宫值空亡，吉凶力量减半，所主之事易落空、宜实不宜虚。 综断此宫平平，按部就班、谨慎行事。

9宫 离（正南）平｜腾蛇·天柱(破军)·生门｜壬加庚 暗戊｜[平]太白擒蛇
离宫主火，关乎名声、文书、眼目、光明。 天柱(破军)入宫，主坚固、口舌、破耗。 生门临宫，吉门，主生发财喜，宜求财开张。 腾蛇临宫，凶神，主虚惊怪异、口舌。 天盘壬加地盘庚，为「太白擒蛇」(平)，难以发展，刑狱公平。 宫克星，受制不利。 宫生门，得生有力。 综断此宫平平，按部就班、谨慎行事。

【AI看盘提示】
以下为茅山派转盘奇门遁甲排盘结果，请严格按以下规则分析，勿自行重新排盘或改动盘内数据：
1. 排盘参数：时家奇门，阴遁2局 (上元)，值符天心落2宫、值使开门落3宫，为全盘纲领。
2. 严格以本盘所列星门神干为准；天禽寄坤二宫(显示"禽芮")，中五宫不排星门神、寄坤二宫论。
3. 吉凶判断规则：
   - 八门：休/生/开/景为吉门，伤/杜/死/惊为凶门；
   - 八神：值符/太阴/六合/九地/九天为吉，腾蛇/白虎/玄武为凶；
   - 门迫(门克宫)为重要凶象，吉门减力、凶门更凶；宫克门则门受制；
   - 空亡之宫吉凶力量减半，所主之事易落空、宜实不宜虚；
   - 驿马临宫主变动、出行、远行有利；
   - 十干克应与格局只按盘中标注判读(如青龙返首、飞鸟跌穴、六仪击刑、五不遇时、奇仪入墓、九星伏吟/反吟等)，勿编造盘外格局。
4. 用神取用：综合判断以值符值使为纲，结合所问之事取用神。
5. 输出要求：先断总体吉凶(以值符值使落宫为纲)，再析用神落宫与关键格局，次论各宫生克，最后给出可执行建议；不确定处明确说明，勿臆断。

- 这是静态网站版的
https://qimen-xxc.netlify.app/